### PR TITLE
Target ubuntu-latest explicitely when running depency-review [DT-7006]

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,3 +15,4 @@ jobs:
     with:
       public: true
       distributed: true
+      runs-on: '["ubuntu-latest"]'


### PR DESCRIPTION
feat: **Target ubuntu-latest directly when running dependency-review **

https://coveord.atlassian.net/browse/DT-7006

Summary of changes:
  - The `dependency-review` workflow now targets `ubuntu-latest` directly instead of using the default.
  
We are changing the default value of the `dependency-review` action to target our self-hosted runners.
Therefore, public repositories must be adjusted prior else they will not be able to run the workflow anymore.


*You should adjust and merge this pull request yourself if you're OK with it. 
Feel free to comment if there's an issue!*
