### PR TITLE
revert ruby version

### DIFF
--- a/.github/workflows/createNewCodeSandBoxDemo.yml
+++ b/.github/workflows/createNewCodeSandBoxDemo.yml
@@ -22,11 +22,11 @@ jobs:
           egress-policy: audit
 
       - name: Setup Ruby in runner
-        uses: ruby/setup-ruby@a25f1e45f0e65a92fcb1e95e8847f78fb0a7197a
+        uses: ruby/setup-ruby@ee26e27437bde475b19a6bf8cb73c9fa658876a2
         with:
-          ruby-version: '3.4.7'
+          ruby-version: '3.2.0'
         env:
-          ImageOS: ubuntu24
+          ImageOS: ubuntu22
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Make a new Branch for version


### PR DESCRIPTION
The Ubuntu22 platform doesn't yet support ruby 3.4.7, so I revert to the most recent supported version.
https://github.com/coveo/headless-documentation-material-ui-react-codesandbox/actions/runs/20350753278/job/58474447112

To use a more recent Ubuntu platform, we need to update the version of the ruby/setup-ruby action allowed by Coveo security: https://github.com/coveo/gha-infra

Created https://coveord.atlassian.net/browse/DOC-18354 to do so