### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/createNewCodeSandBoxDemo.yml
+++ b/.github/workflows/createNewCodeSandBoxDemo.yml
@@ -1,4 +1,6 @@
 name: Create New CodeSandBoxDemo
+permissions:
+  contents: write
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/coveo/headless-documentation-material-ui-react-codesandbox/security/code-scanning/4](https://github.com/coveo/headless-documentation-material-ui-react-codesandbox/security/code-scanning/4)

In general, the problem is fixed by explicitly specifying a `permissions` block in the workflow (at the top level or per job) so that the `GITHUB_TOKEN` used by this workflow has only the minimal required scopes. This overrides potentially broad repository defaults and aligns with the principle of least privilege.

For this specific workflow, the job creates a new branch and pushes it to the repository, which requires write access to the repository contents. It does not interact with issues, pull requests, or other resources, so we can safely limit the token to `contents: write`. The cleanest fix is to add a top-level `permissions` block (between `name:` and `on:` or immediately after `on:`), so it applies to all jobs in this workflow. We only need:

```yaml
permissions:
  contents: write
```

No changes are needed to the job steps or to any imports; this is purely a YAML configuration change in `.github/workflows/createNewCodeSandBoxDemo.yml`. The existing use of `secrets.GITHUB_TOKEN` in the environment will continue to work, but now with an explicitly constrained scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
